### PR TITLE
Storing of best_x between evaluations

### DIFF
--- a/src/heur.py
+++ b/src/heur.py
@@ -26,7 +26,7 @@ class Heuristic:
         self.neval += 1
         if y < self.best_y:
             self.best_y = y
-            self.best_x = x
+            self.best_x = np.copy(x)
         if y <= self.fstar:
             raise StopCriterion('Found solution with desired fstar value')
         if self.neval == self.maxeval:


### PR DESCRIPTION
Since `x` is mostly an array, the assignment `self.best_x = x` is done as a reference. Then, if the original array `x` is modified in a special way, `e.g. x[0] = 1`, the stored value `self.best_x` is inherently changed too. This behavior is unintended and its cause difficult to find. The proposed change solves this by creating a copy of the array `x`.